### PR TITLE
fix support java 16+ in server/java 

### DIFF
--- a/server/java/pom.xml
+++ b/server/java/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.8</version>
+            <version>1.18.22</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/server/java/pom.xml
+++ b/server/java/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>1.18.30</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Before the fix
Lombok `1.18.8` is incompatible with `Java 16` and above

Stackoverflow [Lombok's access to jdk.compiler's internal packages incompatible with Java-16](https://stackoverflow.com/questions/65380359/lomboks-access-to-jdk-compilers-internal-packages-incompatible-with-java-16)

Related to https://github.com/projectlombok/lombok/issues/2681

## After the fix
This fixes the build ( `mvn clean install` ) on  Java 16 and above

--------------
**My environment is:**
Apache Maven 3.9.4
IntelliJ IDEA 2023.2.2 
Lombok 1.18.8 - 1.18-30 
JVM versions tested : jdk1.8.0_121.  , jdk-16.0.1 , Amazon corretto-17.0.5